### PR TITLE
Update Monolog Dependency to Support Laravel 11 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "^2.0 || ^3.0",
         "vlucas/phpdotenv": "5.6.x-dev"
     },
     "autoload": {


### PR DESCRIPTION
This pull request updates the Monolog dependency in the composer.json file to ensure compatibility with Laravel 11. The specific change is as follows:

Updated the Monolog version requirement from "monolog/monolog": "^2.0" to "monolog/monolog": "^2.0 || ^3.0".

This change allows the project to utilize either Monolog version 2 or 3, ensuring continued compatibility and taking advantage of improvements and bug fixes in the latest Monolog release. This update is crucial for supporting Laravel 11, which requires Monolog version 3.