### PR TITLE
Add 202 status code to success responses

### DIFF
--- a/src/Services/FIBPaymentIntegrationService.php
+++ b/src/Services/FIBPaymentIntegrationService.php
@@ -49,7 +49,7 @@ class FIBPaymentIntegrationService implements FIBPaymentIntegrationServiceInterf
 
                 $response = $this->httpClient->request($method, $url, $options);
 
-                if (in_array($response->getStatusCode(), [200, 201 , 202])) {
+                if (in_array($response->getStatusCode(), [200, 201 , 202 , 204])) {
                     return $response;
                 }
 


### PR DESCRIPTION
In the FIBPaymentIntegrationService, the possible successful HTTP status codes have been updated. 202 was added to the array of codes that the logic identifies as indicating a successful request.